### PR TITLE
Check the drop point is not a footer.

### DIFF
--- a/src/com/terlici/dragndroplist/DragNDropListView.java
+++ b/src/com/terlici/dragndroplist/DragNDropListView.java
@@ -141,8 +141,15 @@ public class DragNDropListView extends ListView {
 			default:
 				mDragMode = false;
 				
-				if (mStartPosition != INVALID_POSITION)
-					stopDrag(mStartPosition - getFirstVisiblePosition(), pointToPosition(x,y));
+
+				if (mStartPosition != INVALID_POSITION) {
+					// check if the position is a header/footer
+					int actualPosition =  pointToPosition(x,y);
+					if (actualPosition > (getCount() - getFooterViewsCount()) - 1)
+						actualPosition = INVALID_POSITION;
+
+					stopDrag(mStartPosition - getFirstVisiblePosition(), actualPosition);
+				}
 				break;
 		}
 		


### PR DESCRIPTION
I think this patch addresses the crash caused from dropping an item on the footer when present.

```
 08-01 17:49:09.628  30242-30242/? E/MessageQueue-JNI: java.lang.ArrayIndexOutOfBoundsException: length=7; index=7
 at com.terlici.dragndroplist.DragNDropCursorAdapter.onItemDrop(DragNDropCursorAdapter.java:97)
 at com.terlici.dragndroplist.DragNDropListView.stopDrag(DragNDropListView.java:249)
 at com.terlici.dragndroplist.DragNDropListView.onTouchEvent(DragNDropListView.java:156)
```
