### PR TITLE
Fix drag handler position calculation

### DIFF
--- a/src/com/terlici/dragndroplist/DragNDropListView.java
+++ b/src/com/terlici/dragndroplist/DragNDropListView.java
@@ -103,9 +103,16 @@ public class DragNDropListView extends ListView {
 		
 		if (handler == null) return false;
 		
-		int top = parent.getTop() + handler.getTop();
+		int top = handler.getTop();
+		int left = handler.getLeft();
+		View subParent = handler;
+		do {
+			subParent = (View)subParent.getParent();
+			top += subParent.getTop();
+			left += subParent.getLeft();
+		} while(subParent != parent);
+
 		int bottom = top + handler.getHeight();
-		int left = parent.getLeft() + handler.getLeft();
 		int right = left + handler.getWidth();
 		
 		return left <= x && x <= right && top <= y && y <= bottom;


### PR DESCRIPTION
I noticed, that if you set the drag handler to a view whose parent is not the view generated by the adapter, the dragging-enabled area is not calculated right.

To test this replace the content of testitem.xml (DragNDropListApp) with

```
<TextView
    android:id="@+id/text"
    android:layout_width="wrap_content"
    android:layout_height="wrap_content"
    android:text="Large Text"
    android:textAppearance="?android:attr/textAppearanceLarge" />

<FrameLayout
    android:layout_width="match_parent"
    android:layout_height="match_parent">

    <ImageView
        android:id="@+id/handler"
        android:layout_width="60px"
        android:layout_height="60px"
        android:src="@android:drawable/btn_star_big_on"
        android:layout_marginLeft="8px"
        />
</FrameLayout>
```
